### PR TITLE
Default to HTTPS for requests to pointhq.com

### DIFF
--- a/lib/point.rb
+++ b/lib/point.rb
@@ -25,4 +25,4 @@ module Point
   
 end
 
-Point.site = "http://pointhq.com"
+Point.site = "https://pointhq.com"

--- a/lib/point/request.rb
+++ b/lib/point/request.rb
@@ -27,7 +27,7 @@ module Point
       http_request.add_field("Content-type", "application/json")
       
       http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      http.use_ssl = true if uri.scheme == "https"
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       data = self.data.to_json if self.data.is_a?(Hash) && self.data.respond_to?(:to_json)

--- a/lib/point/request.rb
+++ b/lib/point/request.rb
@@ -27,6 +27,9 @@ module Point
       http_request.add_field("Content-type", "application/json")
       
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
       data = self.data.to_json if self.data.is_a?(Hash) && self.data.respond_to?(:to_json)
       http_result = http.request(http_request, data)
       @output = http_result.body

--- a/lib/point/request.rb
+++ b/lib/point/request.rb
@@ -28,7 +28,6 @@ module Point
       
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.scheme == "https"
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       data = self.data.to_json if self.data.is_a?(Hash) && self.data.respond_to?(:to_json)
       http_result = http.request(http_request, data)


### PR DESCRIPTION
Requests using HTTP are now 301-redirected to their HTTPS equivalent, which means they fail.

This change defaults to using HTTPS URLs, and configures Net::HTTP to use SSL when requesting an HTTPS URL.